### PR TITLE
geographiclib dependency added

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,8 @@
   <depend>image_transport</depend>
   <depend>cv_bridge</depend>
 
+  <depend>geographiclib</depend>
+
   <!-- linting test dependencies -->
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>


### PR DESCRIPTION
closes #25 
[ROS Index](https://index.ros.org/d/geographiclib/)